### PR TITLE
🐛 fix: 책 회전시 표지 이미지 Load가 애니메이팅 이후되는 문제 해결

### DIFF
--- a/src/pages/BookcontentsPage/IndexPage/IndexPage.jsx
+++ b/src/pages/BookcontentsPage/IndexPage/IndexPage.jsx
@@ -23,6 +23,7 @@ export default function IndexPage() {
     const [isButtonShow, setIsButtonShow] = useState(false);
     const [isMovetoChapter, setIsMovetoChapter] = useState(false);
     const [isBeforeChapter] = useState(state);
+    const [isImageLoaded, setIsImageLoaded] = useState(false);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -53,6 +54,7 @@ export default function IndexPage() {
             <BookBox
                 isMovetoChapter={isMovetoChapter}
                 isBeforeChapter={isBeforeChapter}
+                isImageLoaded={isImageLoaded}
             >
                 <BookSpine bgUrl={`../img/spine/spine${id}.png`}>
                     <button>
@@ -64,6 +66,7 @@ export default function IndexPage() {
                     bgUrl={`../img/cover/cover${id}.png`}
                     color={color}
                     isBeforeChapter={isBeforeChapter}
+                    isImageLoaded={isImageLoaded}
                 >
                     <li>
                         <h2> {title}</h2>
@@ -109,6 +112,15 @@ export default function IndexPage() {
                     />
                 )}
             </BookBox>
+            <img
+                src={`../img/cover/cover${id}.png`}
+                alt="커버 이미지 로드 확인용"
+                style={{ display: 'none' }}
+                onLoad={() => {
+                    setIsImageLoaded(true);
+                    console.log('이미지로드');
+                }}
+            />
         </IndexPageWrapper>
     );
 }

--- a/src/pages/BookcontentsPage/IndexPage/IndexPageStyle.jsx
+++ b/src/pages/BookcontentsPage/IndexPage/IndexPageStyle.jsx
@@ -33,6 +33,7 @@ const bookRotate = keyframes`
 
 const bookOpen = keyframes`
     0%{
+        transform: translateX(0);
     }
     100%{
         transform: translateX(1098px);
@@ -41,11 +42,27 @@ const bookOpen = keyframes`
 
 const mobileBookOpen = keyframes`
     0%{
+        transform: translateX(0);
     }
     100%{
         transform: translateX(100%);
     }
 `;
+const bookRotateOpenAnimation = p => css`
+    animation: ${p.isImageLoaded &&
+    css`
+        ${bookRotate} 1.2s ease-in-out forwards,
+        ${bookOpen} 1.5s 1.2s forwards;
+    `};
+`;
+const mobileBookRotateOpenAnimation = p => css`
+    animation: ${p.isImageLoaded &&
+    css`
+        ${bookRotate} 1.2s ease-in-out forwards,
+        ${mobileBookOpen} 1.5s 1.2s forwards;
+    `};
+`;
+
 const bookSlide = keyframes`
     0%{
         transform: translateX(1098px);
@@ -91,9 +108,8 @@ export const BookBox = styled.div`
     width: 1098px;
     height: 680px;
     transform-style: preserve-3d;
-    animation:
-        ${bookRotate} 1.2s ease-in-out forwards,
-        ${bookOpen} 1.5s 1.2s forwards;
+
+    ${bookRotateOpenAnimation}
     ${nonAnimateBox}
     ${bookSlideAnimate}
 
@@ -103,9 +119,8 @@ export const BookBox = styled.div`
         display: flex;
         justify-content: center;
         align-items: center;
-        animation:
-            ${bookRotate} 1.2s ease-in-out forwards,
-            ${mobileBookOpen} 1.5s 1.2s forwards;
+
+        ${mobileBookRotateOpenAnimation}
         ${nonAnimateBox}
         ${mobileBookSlideAnimate}
     }
@@ -158,6 +173,13 @@ const coverFrontOpen = keyframes`
     }
 `;
 
+const coverFrontOpenAnimation = p => css`
+    animation: ${p.isImageLoaded &&
+    css`
+        ${coverFrontOpen} 2s 1.2s forwards;
+    `};
+`;
+
 const nonAnimateCover = p => css`
     animation: ${p.isBeforeChapter &&
     css`
@@ -177,7 +199,8 @@ export const BookCoverFront = styled.ul`
     }
     transform: translate3d(0, 0, 50px);
     transform-origin: left top;
-    animation: ${coverFrontOpen} 2s 1.2s forwards;
+
+    ${coverFrontOpenAnimation}
     ${nonAnimateCover}
 
     /* 앞면 */


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
책 회전시 표지 이미지 Load가 애니메이팅 이후되는 문제를 해결한다.

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 표지 이미지 로드 상태에 대한 state값을 만들어 이후 애니메이팅이 구현되도록 수정했다.
- 창 크기 조정시 키프레임 0에 값이 없어 발생한 애니메이팅 문제를 해결했다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #44 

<br><br>
